### PR TITLE
Remove call to kruptein.get() from touch()

### DIFF
--- a/lib/connect-redis-crypto.js
+++ b/lib/connect-redis-crypto.js
@@ -84,14 +84,6 @@ module.exports = function(session) {
 
       let key = this.prefix + sid
 
-      if (this.secret) {
-        this.kruptein.get(this.secret, sess, (err, pt) => {
-          if (err) return cb(err)
-
-          sess = pt
-        })
-      }
-
       this.client.expire(key, this._getTTL(sess), (err, ret) => {
         if (err) return cb(err)
         if (ret !== 1) return cb(null, 'EXPIRED')


### PR DESCRIPTION
Call to touch() is coming from session manager which has the cleartext session value. No need to call kruptein.get()