### PR TITLE
Fix initial TTL on set

### DIFF
--- a/lib/connect-redis-crypto.js
+++ b/lib/connect-redis-crypto.js
@@ -58,6 +58,7 @@ module.exports = function(session) {
 
     set(sid, sess, cb = noop) {
       let args = [this.prefix + sid]
+      const ttl = this._getTTL(sess)
 
       if (this.secret) {
         this.kruptein.set(this.secret, sess, (err, ct) => {
@@ -74,7 +75,7 @@ module.exports = function(session) {
         return cb(er)
       }
       args.push(value)
-      args.push('EX', this._getTTL(sess))
+      args.push('EX', ttl)
 
       this.client.set(args, cb)
     }


### PR DESCRIPTION
The initial TTL fetch for the `set` method was getting the default TTL set in the options.
This is because a call to `_getTTL` was made after encrypting the session object, which meant the checks on the cookie were now invalid.

Moving the call to TTL before the encryption